### PR TITLE
Interpolate the command provided by mc_rtc

### DIFF
--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -35,8 +35,6 @@ private:
   std::vector<std::string> mj_jnt_names;
   std::vector<int> mj_jnt_ids;
 
-  /** Transform mj_act index to mj_jnt index */
-  std::vector<size_t> mj_act_to_jnt;
   /** Transform from index in mj_act_names to index in mbc, -1 if not in mbc */
   std::vector<int> mj_to_mbc;
   /** Command send to mujoco */
@@ -157,7 +155,7 @@ public:
   {
     // get names of all joints
     mujoco_get_joints(mj_jnt_names, mj_jnt_ids);
-    // get names of actuated joints
+    // get names of acuated joints
     mujoco_get_motors(mj_act_names, mj_act_ids);
 
     mj_to_mbc.resize(0);

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -30,12 +30,12 @@ private:
   std::vector<double> kp = {};
   std::vector<double> kd = {};
 
-  std::vector<std::string> mj_act_names;
-  std::vector<int> mj_act_ids;
+  std::vector<std::string> mj_mot_names;
+  std::vector<int> mj_mot_ids;
   std::vector<std::string> mj_jnt_names;
   std::vector<int> mj_jnt_ids;
 
-  /** Transform from index in mj_act_names to index in mbc, -1 if not in mbc */
+  /** Transform from index in mj_mot_names to index in mbc, -1 if not in mbc */
   std::vector<int> mj_to_mbc;
   /** Command send to mujoco */
   std::vector<double> mj_ctrl;
@@ -156,13 +156,13 @@ public:
     // get names of all joints
     mujoco_get_joints(mj_jnt_names, mj_jnt_ids);
     // get names of acuated joints
-    mujoco_get_motors(mj_act_names, mj_act_ids);
+    mujoco_get_motors(mj_mot_names, mj_mot_ids);
 
     mj_to_mbc.resize(0);
     mj_prev_ctrl_q.resize(0);
     mj_prev_ctrl_alpha.resize(0);
     const auto & robot = controller.robot();
-    for(const auto & jn : mj_act_names)
+    for(const auto & jn : mj_mot_names)
     {
       if(robot.hasJoint(jn))
       {
@@ -359,7 +359,7 @@ public:
     }
     for(size_t i = 0; i < mj_ctrl.size(); ++i)
     {
-      auto jnt_idx = mj_act_ids[i]-1; // subtract 1 because mujoco counts from the "freejoint"
+      auto jnt_idx = mj_mot_ids[i]-1; // subtract 1 because mujoco counts from the "freejoint"
       mj_ctrl[i] =
           PD(jnt_idx, mj_prev_ctrl_q[i] + (interp_idx + 1) * (mj_next_ctrl_q[i] - mj_prev_ctrl_q[i]) / frameskip_,
              encoders[jnt_idx],

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -153,9 +153,9 @@ public:
 
   void startSimulation()
   {
-    // get names of all joints
+    // get names and ids of all joints
     mujoco_get_joints(mj_jnt_names, mj_jnt_ids);
-    // get names of acuated joints
+    // get names and ids of actuated joints
     mujoco_get_motors(mj_mot_names, mj_mot_ids);
 
     mj_to_mbc.resize(0);

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -323,25 +323,29 @@ bool mujoco_get_sensordata(std::vector<double> & read, const std::string & senso
   return (read.size() ? true : false);
 }
 
-void mujoco_get_joint_names(std::vector<std::string> & names)
+void mujoco_get_joints(std::vector<std::string> & names, std::vector<int> & ids)
 {
   names.clear();
+  ids.clear();
   for(size_t i = 0; i < m->njnt; ++i)
   {
     if(m->jnt_type[i] != mjJNT_FREE)
     {
       names.push_back(mj_id2name(m, mjOBJ_JOINT, i));
+      ids.push_back(i);
     }
   }
 }
 
-void mujoco_get_motor_names(std::vector<std::string> & names)
+void mujoco_get_motors(std::vector<std::string> & names, std::vector<int> & ids)
 {
   names.clear();
+  ids.clear();
   for(size_t i = 0; i < m->nu; ++i)
   {
     unsigned int jnt_id = m->actuator_trnid[2 * i];
     names.push_back(mj_id2name(m, mjOBJ_JOINT, jnt_id));
+    ids.push_back(jnt_id);
   }
 }
 

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -350,7 +350,7 @@ bool mujoco_set_ctrl(const std::vector<double> & ctrl)
   mju_zero(d->ctrl, m->nu);
   if(ctrl.size() != m->nu)
   {
-    std::cerr << "Invalid size of control signal(" << ctrl.size() << ")." << std::endl;
+    std::cerr << "Invalid size of control signal(" << ctrl.size() << ", expected " << m->nu << ")." << std::endl;
     return false;
   }
   // TODO: Check if mapping is correct.

--- a/src/mj_utils.h
+++ b/src/mj_utils.h
@@ -50,11 +50,11 @@ void mujoco_get_joint_vel(std::vector<double> & qvel);
  */
 bool mujoco_get_sensordata(std::vector<double> & read, const std::string & sensor_name);
 
-/*! Get names of all joints except the freejoint. */
-void mujoco_get_joint_names(std::vector<std::string> & names);
+/*! Get names and ids of all joints except the freejoint. */
+void mujoco_get_joints(std::vector<std::string> & names, std::vector<int> & ids);
 
-/*! Get names of all actuated joints (NOT the names of actuators). */
-void mujoco_get_motor_names(std::vector<std::string> & names);
+/*! Get names and ids of all actuated joints (NOT the names of actuators). */
+void mujoco_get_motors(std::vector<std::string> & names, std::vector<int> & ids);
 
 /*! Sets the control data after scaling down by gear ratio.
  * Returns false if there is a vector size mismatch.


### PR DESCRIPTION
- Fixes stability issues when mc_rtc timestep != mujoco timestep
- Cache the mujoco joint order to mbc joint order correspondance
- Use the desired joint velocity as well