### PR TITLE
set contype and conaffinity to 0 for floors in robot XML

### DIFF
--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -236,15 +236,15 @@ bool mujoco_init(MjSimImpl * mj_sim, const std::vector<std::string> & robots, co
   }
 
   // disable all floors (if any) except ground_floor
-  for (auto robot : robots)
+  for(auto robot : robots)
   {
-    if (robot=="ground")
+    if(robot == "ground")
     {
       continue;
     }
     std::string floor = robot + "_floor";
     int floor_id = mj_name2id(mj_sim->model, mjOBJ_GEOM, floor.c_str());
-    if (floor_id != -1)
+    if(floor_id != -1)
     {
       mj_sim->model->geom_conaffinity[floor_id] = 0;
       mj_sim->model->geom_contype[floor_id] = 0;


### PR DESCRIPTION
@gergondet How about this solution to the issue of multiple floors being loaded (mentioned here: https://github.com/isri-aist/hrp5p_mj_description/pull/3)?
I think setting disabling collision detection for the floor inside of robot XML should not impact the simulation speed.
