### PR TITLE
GUI tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,10 @@ jobs:
         set -e
         mkdir -p /opt
         cd /opt
-        wget --quiet https://www.roboti.us/download/mujoco200_linux.zip
-        unzip mujoco200_linux.zip
-        mv mujoco200_linux mujoco
-        rm -rf mujoco200_linux.zip
+        wget --quiet https://mujoco.org/download/mujoco210-linux-x86_64.tar.gz
+        tar xzf mujoco210-linux-x86_64.tar.gz
+        mv mujoco210 mujoco
+        rm -rf mujoco210-linux-x86_64.tar.gz
         echo "MUJOCO_ROOT_DIR=/opt/mujoco" >> $GITHUB_ENV
     - name: Build and test
       uses: jrl-umi3218/github-actions/build-cmake-project@master

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # [WIP] Mujoco interface for mc-rtc
 
-Add this to your mc-rtc configuration yaml:
-
-```yaml
-MUJOCO:
-  xmlModelPath: "<path_to_your_xml_model>"
-  pdGainsPath: "<path_to_your_pdgains>"
-```
-
 ### Usage
 
 Assuming that you have mujoco installed under `${HOME}/.mujoco/mujoco200`,
@@ -32,7 +24,8 @@ $ ./src/mc_mujoco
 
 ### GUI
 
-**Apply external force**  
+**Apply external force**
+
 An object is selected by left-double-click. The user can then apply forces and torques on the selected object by holding Ctrl and dragging the mouse.
 
 ### Credits

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,8 +58,14 @@ int main(int argc, char * argv[])
     config.with_controller = !vm["without-controller"].as<bool>();
     config.with_visualization = !vm["without-visualization"].as<bool>();
     config.with_mc_rtc_gui = !vm["without-mc-rtc-gui"].as<bool>();
-    config.visualize_visual = !vm["without-visuals"].as<bool>();
-    config.visualize_collisions = vm["with-collisions"].as<bool>();
+    if(!vm["without-visuals"].defaulted())
+    {
+      config.visualize_visual = !vm["without-visuals"].as<bool>();
+    }
+    if(!vm["with-collisions"].defaulted())
+    {
+      config.visualize_collisions = vm["with-collisions"].as<bool>();
+    }
   }
   mc_mujoco::MjSim mj_sim(config);
 

--- a/src/mj_configuration.h
+++ b/src/mj_configuration.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 namespace mc_mujoco
@@ -11,9 +12,9 @@ struct MjConfiguration
   /** If true, enable visualization */
   bool with_visualization = true;
   /** If true, display the collision model by default */
-  bool visualize_collisions = false;
+  std::optional<bool> visualize_collisions;
   /** If true, display the visual model by default */
-  bool visualize_visual = true;
+  std::optional<bool> visualize_visual;
   /** If true, enable mc_rtc GUI inside MuJoCo simulation */
   bool with_mc_rtc_gui = true;
   /** If true, enable mc_rtc controller inside MuJoCo simulation */

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -629,7 +629,7 @@ bool MjSimImpl::render()
     auto height = io.DisplaySize.y - 2 * top_margin;
     ImGui::SetNextWindowPos({0.8f * width - right_margin, top_margin}, ImGuiCond_FirstUseEver);
     ImGui::SetNextWindowSize({0.2f * width, 0.3f * height}, ImGuiCond_FirstUseEver);
-    ImGui::Begin("mc_mujoco");
+    ImGui::Begin(fmt::format("mc_mujoco (MuJoCo {})", mj_version()).c_str());
     size_t nsamples = std::min(mj_sim_dt.size(), iterCount_);
     mj_sim_dt_average = 0;
     for(size_t i = 0; i < nsamples; ++i)

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -703,6 +703,38 @@ bool MjSimImpl::render()
 
 void MjSimImpl::stopSimulation() {}
 
+void MjSimImpl::saveGUISettings()
+{
+  auto user_path = bfs::path(USER_FOLDER);
+  if(!bfs::exists(user_path))
+  {
+    if(!bfs::create_directories(user_path))
+    {
+      mc_rtc::log::critical("Failed to create the user directory: {}. GUI configuration will not be saved",
+                            user_path.string());
+      return;
+    }
+  }
+  mc_rtc::Configuration config;
+  auto camera_c = config.add("camera");
+  auto lookat = camera_c.array("lookat", 3);
+  for(size_t i = 0; i < 3; ++i)
+  {
+    lookat.push(camera.lookat[i]);
+  }
+  camera_c.add("distance", camera.distance);
+  camera_c.add("azimuth", camera.azimuth);
+  camera_c.add("elevation", camera.elevation);
+  auto visualize_c = config.add("visualize");
+  visualize_c.add("collisions", static_cast<bool>(options.geomgroup[0]));
+  visualize_c.add("visuals", static_cast<bool>(options.geomgroup[1]));
+  visualize_c.add("contact-points", static_cast<bool>(options.flags[mjVIS_CONTACTPOINT]));
+  visualize_c.add("contact-forces", static_cast<bool>(options.flags[mjVIS_CONTACTFORCE]));
+  auto path_out = (user_path / "mc_mujoco.yaml").string();
+  config.save(path_out);
+  mc_rtc::log::success("[mc_mujoco] Configuration saved to {}", path_out);
+}
+
 MjSim::MjSim(const MjConfiguration & config) : impl(new MjSimImpl(config))
 {
   impl->startSimulation();

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -628,7 +628,7 @@ bool MjSimImpl::render()
     auto width = io.DisplaySize.x - 2 * right_margin;
     auto height = io.DisplaySize.y - 2 * top_margin;
     ImGui::SetNextWindowPos({0.8f * width - right_margin, top_margin}, ImGuiCond_FirstUseEver);
-    ImGui::SetNextWindowSize({0.2f * width, 0.2f * height}, ImGuiCond_FirstUseEver);
+    ImGui::SetNextWindowSize({0.2f * width, 0.3f * height}, ImGuiCond_FirstUseEver);
     ImGui::Begin("mc_mujoco");
     size_t nsamples = std::min(mj_sim_dt.size(), iterCount_);
     mj_sim_dt_average = 0;
@@ -664,6 +664,31 @@ bool MjSimImpl::render()
       doNStepsButton(10, false);
       doNStepsButton(50, false);
       doNStepsButton(100, true);
+    }
+    auto flag_to_gui = [&](const char * label, mjtVisFlag flag) {
+      bool show = options.flags[flag];
+      if(ImGui::Checkbox(label, &show))
+      {
+        options.flags[flag] = show;
+      }
+    };
+    flag_to_gui("Show contact points [C]", mjVIS_CONTACTPOINT);
+    flag_to_gui("Show contact forces [F]", mjVIS_CONTACTFORCE);
+    auto group_to_checkbox = [&](size_t group, bool last) {
+      bool show = options.geomgroup[group];
+      if(ImGui::Checkbox(fmt::format("{}", group).c_str(), &show))
+      {
+        options.geomgroup[group] = show;
+      }
+      if(!last)
+      {
+        ImGui::SameLine();
+      }
+    };
+    ImGui::Text("%s", fmt::format("Visible layers [0-{}]", mjNGROUP).c_str());
+    for(size_t i = 0; i < mjNGROUP; ++i)
+    {
+      group_to_checkbox(i, i == mjNGROUP - 1);
     }
     ImGui::End();
   }

--- a/src/mj_sim_impl.h
+++ b/src/mj_sim_impl.h
@@ -217,6 +217,8 @@ public:
   bool render();
 
   void stopSimulation();
+
+  void saveGUISettings();
 };
 
 } // namespace mc_mujoco

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -70,8 +70,8 @@ void uiEvent(mjuiState * state)
     {
       mj_sim->options.flags[mjVIS_CONTACTFORCE] = !mj_sim->options.flags[mjVIS_CONTACTFORCE];
     }
-    // 0-9: Toggle visiblity of geom groups
-    if(state->key >= GLFW_KEY_0 && state->key <= GLFW_KEY_9)
+    // 0-mjNGROUP: Toggle visiblity of geom groups
+    if(state->key >= GLFW_KEY_0 && state->key < (GLFW_KEY_0 + mjNGROUP))
     {
       int group = state->key - GLFW_KEY_0;
       mj_sim->options.geomgroup[group] = !mj_sim->options.geomgroup[group];

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -17,6 +17,9 @@
 
 #include "Robot_Regular_ttf.h"
 
+#include <boost/filesystem.hpp>
+namespace bfs = boost::filesystem;
+
 namespace mc_mujoco
 {
 
@@ -75,6 +78,11 @@ void uiEvent(mjuiState * state)
     {
       int group = state->key - GLFW_KEY_0;
       mj_sim->options.geomgroup[group] = !mj_sim->options.geomgroup[group];
+    }
+    // Ctrl+S save the visualization state
+    if(state->key == GLFW_KEY_S && state->control)
+    {
+      mj_sim->saveGUISettings();
     }
     return;
   }
@@ -266,15 +274,28 @@ void mujoco_create_window(MjSimImpl * mj_sim)
   glfwSetWindowUserPointer(mj_sim->window, static_cast<void *>(mj_sim));
 
   // initialize visualization data structures
-  mj_sim->camera.lookat[0] = 0.0f;
-  mj_sim->camera.lookat[1] = 0.0f;
-  mj_sim->camera.lookat[2] = 0.75f;
-  mj_sim->camera.distance = 6.0f;
-  mj_sim->camera.azimuth = -150.0f;
-  mj_sim->camera.elevation = -20.0f;
+  auto config = [&]() -> mc_rtc::Configuration {
+    auto path = fmt::format("{}/mc_mujoco.yaml", USER_FOLDER);
+    if(bfs::exists(path))
+    {
+      return {path};
+    }
+    return {};
+  }();
+  auto camera = config("camera", mc_rtc::Configuration{});
+  auto lookat = camera("lookat", std::array<double, 3>{0.0, 0.0, 0.75});
+  mj_sim->camera.lookat[0] = static_cast<float>(lookat[0]);
+  mj_sim->camera.lookat[1] = static_cast<float>(lookat[1]);
+  mj_sim->camera.lookat[2] = static_cast<float>(lookat[2]);
+  mj_sim->camera.distance = static_cast<float>(camera("distance", 6.0));
+  mj_sim->camera.azimuth = static_cast<float>(camera("azimuth", -150.0));
+  mj_sim->camera.elevation = static_cast<float>(camera("elevation", -20.0));
   mjv_defaultOption(&mj_sim->options);
-  mj_sim->options.geomgroup[0] = mj_sim->config.visualize_collisions;
-  mj_sim->options.geomgroup[1] = mj_sim->config.visualize_visual;
+  auto visualize = config("visualize", mc_rtc::Configuration{});
+  mj_sim->options.geomgroup[0] = mj_sim->config.visualize_collisions.value_or(visualize("collisions", false));
+  mj_sim->options.geomgroup[1] = mj_sim->config.visualize_visual.value_or(visualize("visuals", true));
+  mj_sim->options.flags[mjVIS_CONTACTPOINT] = visualize("contact-points", false);
+  mj_sim->options.flags[mjVIS_CONTACTFORCE] = visualize("contact-forces", false);
   mjv_defaultScene(&mj_sim->scene);
   mjr_defaultContext(&mj_sim->context);
 

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -50,11 +50,11 @@ void uiEvent(mjuiState * state)
 {
   auto mj_sim = static_cast<MjSimImpl *>(state->userdata);
 
-  if(ImGui::GetIO().WantCaptureKeyboard)
+  if(state->type == mjEVENT_KEY && ImGui::GetIO().WantCaptureKeyboard)
   {
     return;
   }
-  if(ImGui::GetIO().WantCaptureMouse)
+  if(state->type != mjEVENT_KEY && ImGui::GetIO().WantCaptureMouse)
   {
     return;
   }

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -209,6 +209,7 @@ void uiEvent(mjuiState * state)
 
 bool mujoco_init(MjSimImpl * mj_sim, const std::vector<std::string> & robots, const std::vector<std::string> & xmlFiles)
 {
+#if mjVERSION_HEADER <= 200
   // Initialize MuJoCo
   if(!mujoco_initialized)
   {
@@ -224,6 +225,7 @@ bool mujoco_init(MjSimImpl * mj_sim, const std::vector<std::string> & robots, co
     mj_activate(key_buf.c_str());
     mujoco_initialized = true;
   }
+#endif
 
   // Load the model;
   std::string model = merge_mujoco_models(robots, xmlFiles, mj_sim->robots);


### PR DESCRIPTION
(and MuJoCo 2.1 "support" sneaked in for good measures)

This PR adds two major things:
- Checkboxes to control the display in MuJoCo (contact force/position + visibility layers)
- Save and load the interface configuration when pushing ctrl+s so that the camera position can be restored