### PR TITLE
Topic/gui features

### DIFF
--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -754,7 +754,7 @@ bool MjSimImpl::render()
     {
       group_to_checkbox(i, i == mjNGROUP - 1);
     }
-    if(ImGui::Button("Reset simulation"))
+    if(ImGui::Button("Reset simulation", ImVec2(-FLT_MIN, 0.0f)))
     {
       reset_simulation_ = true;
     }

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -738,6 +738,7 @@ bool MjSimImpl::render()
     };
     flag_to_gui("Show contact points [C]", mjVIS_CONTACTPOINT);
     flag_to_gui("Show contact forces [F]", mjVIS_CONTACTFORCE);
+    flag_to_gui("Make Transparent [T]", mjVIS_TRANSPARENT);
     auto group_to_checkbox = [&](size_t group, bool last) {
       bool show = options.geomgroup[group];
       if(ImGui::Checkbox(fmt::format("{}", group).c_str(), &show))

--- a/src/mj_sim_impl.h
+++ b/src/mj_sim_impl.h
@@ -196,6 +196,9 @@ public:
   /** Average of the last 1024 iterations */
   double mj_sim_dt_average;
 
+  /** Number of steps left to play in step by step mode */
+  size_t rem_steps = 0;
+
   /** Robots in simulation and mc_rtc */
   std::vector<MjRobot> robots;
 
@@ -204,9 +207,6 @@ private:
   size_t iterCount_ = 0;
   /** How often we run mc_rtc relative to MuJoCo physics */
   size_t frameskip_ = 1;
-
-  /** Number of steps left to play in step by step mode */
-  size_t rem_steps = 0;
 
   /** True if the simulation should be reset on the next step */
   bool reset_simulation_ = false;

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -84,6 +84,33 @@ void uiEvent(mjuiState * state)
     {
       mj_sim->saveGUISettings();
     }
+    // SPACE: play/pause the simulation
+    if(state->key == GLFW_KEY_SPACE)
+    {
+      mj_sim->config.step_by_step = !mj_sim->config.step_by_step;
+    }
+    // RIGHT: advance simulation by one control step
+    if(state->key == GLFW_KEY_RIGHT)
+    {
+      if(mj_sim->config.step_by_step)
+      {
+	mj_sim->rem_steps = 1;
+      }
+    }
+    // E: visualize frames
+    if(state->key == GLFW_KEY_E)
+    {
+      mj_sim->options.frame += 1;
+      if(mj_sim->options.frame==mjNFRAME)
+      {
+	mj_sim->options.frame = 0;
+      }
+    }
+    // T: make transparent
+    if(state->key == GLFW_KEY_T)
+    {
+      mj_sim->options.flags[mjVIS_TRANSPARENT] = !mj_sim->options.flags[mjVIS_TRANSPARENT];
+    }
     return;
   }
 

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -94,16 +94,16 @@ void uiEvent(mjuiState * state)
     {
       if(mj_sim->config.step_by_step)
       {
-	mj_sim->rem_steps = 1;
+        mj_sim->rem_steps = 1;
       }
     }
     // E: visualize frames
     if(state->key == GLFW_KEY_E)
     {
       mj_sim->options.frame += 1;
-      if(mj_sim->options.frame==mjNFRAME)
+      if(mj_sim->options.frame == mjNFRAME)
       {
-	mj_sim->options.frame = 0;
+        mj_sim->options.frame = 0;
       }
     }
     // T: make transparent


### PR DESCRIPTION
Adds a few more keyboard shortcuts to affect the visualization:
- Make the scene slightly transparent -> Key T
- Cycle through mjtFrames (Bodies, joints, geoms,..) -> Key E
- Pause/play the simulation -> SPACE
- Advance the simulation state by one control timesteps -> RIGHT Arrow

Possible upgrades for future:
- Take screenshot
- Record a video
- Render robot trajectory
