### PR TITLE
Fix step-by-step from GUI

### DIFF
--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -634,7 +634,12 @@ bool MjSimImpl::stepSimulation()
   }
   if(config.step_by_step && rem_steps > 0)
   {
-    done = do_step();
+    // Doing 'frameskip_' steps of sim + control
+    // (But controller.run() will execute only when interp_idx == 0)
+    for (unsigned int i; i < frameskip_; i++)
+    {
+      done = do_step();
+    }
     rem_steps--;
   }
   if(config.sync_real_time)

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -636,7 +636,7 @@ bool MjSimImpl::stepSimulation()
   {
     // Doing 'frameskip_' steps of sim + control
     // (But controller.run() will execute only when interp_idx == 0)
-    for (unsigned int i; i < frameskip_; i++)
+    for(unsigned int i; i < frameskip_; i++)
     {
       done = do_step();
     }

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -636,9 +636,9 @@ bool MjSimImpl::stepSimulation()
   {
     // Doing 'frameskip_' steps of sim + control
     // (But controller.run() will execute only when interp_idx == 0)
-    for(unsigned int i; i < frameskip_; i++)
+    for(size_t i = 0; i < frameskip_; i++)
     {
-      done = do_step();
+      done = do_step() && done;
     }
     rem_steps--;
   }


### PR DESCRIPTION
Without this patch, pressing the "+{}ms" in the GUI will only cause one simulation step to be executed, in step-by-step mode.  
So if mc-rtc timestep is 5ms and the simulation timestep is 1ms, the "+5ms" button was needed to be pressed 5 times for one controller::run() to be executed.
The expected behaviour is that if the +5ms button is pressed once, that should call the controller::run() once.  
If the +25ms button is pressed once, that should lead to controller::run() being called 5 times... and so on.

If my understanding is correct, is this is the best way to fix this?
I added some comments too make it clearer.