### PR TITLE
Implement modifiable PD gains with datastore call

### DIFF
--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -385,18 +385,34 @@ void MjSimImpl::makeDatastoreCalls()
   for(auto & r : robots)
   {
     controller->controller().datastore().make_call(
-        "set_pdgains::" + r.name, [this, &r](const std::vector<double> & p_vec, const std::vector<double> & d_vec) {
+        r.name + "::SetPDGains", [this, &r](const std::vector<double> & p_vec, const std::vector<double> & d_vec) {
           const auto & rjo = controller->robots().robot(r.name).module().ref_joint_order();
           if(p_vec.size() != rjo.size())
           {
+            mc_rtc::log::error("[mc_mujoco] {}::SetPDGains failed. p_vec size({})!=ref_joint_order size({})", r.name,
+                               p_vec.size(), rjo.size());
             return false;
           }
           if(d_vec.size() != rjo.size())
           {
+            mc_rtc::log::error("[mc_mujoco] {}::SetPDGains failed. d_vec size({})!=ref_joint_order size({})", r.name,
+                               d_vec.size(), rjo.size());
             return false;
           }
           r.kp = p_vec;
           r.kd = d_vec;
+          return true;
+        });
+  }
+  // make_call for reading pd gains
+  for(auto & r : robots)
+  {
+    controller->controller().datastore().make_call(
+        r.name + "::GetPDGains", [this, &r](std::vector<double> & p_vec, std::vector<double> & d_vec) {
+          p_vec.resize(0);
+          d_vec.resize(0);
+          p_vec = r.kp;
+          d_vec = r.kd;
           return true;
         });
   }

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -406,7 +406,7 @@ void MjSimImpl::makeDatastoreCalls()
 
     // make_call for setting pd gains (by name)
     controller->controller().datastore().make_call(
-        r.name + "::SetPDGainsByName", [this, &r](const std::string & jn, const double & p, const double & d) {
+        r.name + "::SetPDGainsByName", [this, &r](const std::string & jn, double p, double d) {
           const auto & rjo = controller->robots().robot(r.name).module().ref_joint_order();
           auto rjo_it = std::find(rjo.begin(), rjo.end(), jn);
           if(rjo_it == rjo.end())

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -428,6 +428,19 @@ void MjSimImpl::makeDatastoreCalls()
           d_vec.resize(0);
           p_vec = r.kp;
           d_vec = r.kd;
+          const auto & rjo = controller->robots().robot(r.name).module().ref_joint_order();
+          if(p_vec.size() != rjo.size())
+          {
+            mc_rtc::log::warning("[mc_mujoco] {}::GetPDGains failed. p_vec size({})!=ref_joint_order size({})", r.name,
+                                 p_vec.size(), rjo.size());
+            return false;
+          }
+          if(d_vec.size() != rjo.size())
+          {
+            mc_rtc::log::warning("[mc_mujoco] {}::GetPDGains failed. d_vec size({})!=ref_joint_order size({})", r.name,
+                                 d_vec.size(), rjo.size());
+            return false;
+          }
           return true;
         });
 

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -389,14 +389,14 @@ void MjSimImpl::makeDatastoreCalls()
           const auto & rjo = controller->robots().robot(r.name).module().ref_joint_order();
           if(p_vec.size() != rjo.size())
           {
-            mc_rtc::log::error("[mc_mujoco] {}::SetPDGains failed. p_vec size({})!=ref_joint_order size({})", r.name,
-                               p_vec.size(), rjo.size());
+            mc_rtc::log::warning("[mc_mujoco] {}::SetPDGains failed. p_vec size({})!=ref_joint_order size({})", r.name,
+                                 p_vec.size(), rjo.size());
             return false;
           }
           if(d_vec.size() != rjo.size())
           {
-            mc_rtc::log::error("[mc_mujoco] {}::SetPDGains failed. d_vec size({})!=ref_joint_order size({})", r.name,
-                               d_vec.size(), rjo.size());
+            mc_rtc::log::warning("[mc_mujoco] {}::SetPDGains failed. d_vec size({})!=ref_joint_order size({})", r.name,
+                                 d_vec.size(), rjo.size());
             return false;
           }
           r.kp = p_vec;

--- a/src/mj_sim_impl.h
+++ b/src/mj_sim_impl.h
@@ -60,9 +60,13 @@ struct MjRobot
   /** Accelerometer readings */
   std::map<std::string, Eigen::Vector3d> accelerometers;
 
-  /** Proportional gains for low-level PD control */
+  /** Proportional gains for low-level PD control (read from file) */
+  std::vector<double> default_kp = {};
+  /** Derivative gains for low-level PD control (read from file) */
+  std::vector<double> default_kd = {};
+  /** Proportional gains for low-level PD control (used in PD loop) */
   std::vector<double> kp = {};
-  /** Derivative gains for low-level PD control */
+  /** Derivative gains for low-level PD control (used in PD loop) */
   std::vector<double> kd = {};
 
   /** Names of the motors inside MuJoCo corresponding to the joints in \ref mj_jnt_names the name is empty if the joint
@@ -218,6 +222,8 @@ public:
   MjSimImpl(const MjConfiguration & config);
 
   void cleanup();
+
+  void makeDatastoreCalls();
 
   void startSimulation();
 


### PR DESCRIPTION
Hi @gergondet 

I wanted to implement a datastore call to be able to set the PD gains for all joints from within any mc-rtc controller. 
Right now I'm doing works well with what is shown in the patch below.  

Since later I want to implement the same call (with the exact same signature) in [mc-openrtm](https://github.com/jrl-umi3218/mc_openrtm) too,  
I would like to know your suggestions on whether this is the best way to implement it.


<details>
<summary>How to call</summary>

```
  // set new pd gains                                                                                                                                                          
  bool mod_servo_success = false;
  if(ctl.datastore().has("set_pdgains::" + ctl.robot().name()))
  {
    mod_servo_success = ctl.datastore().call<bool>("set_pdgains::" + ctl.robot().name(), kp, kd);
  }

  if (!mod_servo_success)
  {
    mc_rtc::log::warning("[{}] Could not set PD gains through datastore call!!!", name());
  }
```
</details>