### PR TITLE
Error in number of joints in simulation with soft objects

### DIFF
--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -256,6 +256,10 @@ void MjRobot::initialize(mjModel * model, const mc_rbdyn::Robot & robot)
   {
     root_body_id = mj_name2id(model, mjOBJ_BODY, root_body.c_str());
   }
+  if(root_joint.size())
+  {
+    root_joint_id = mj_name2id(model, mjOBJ_JOINT, root_joint.c_str());
+  }
   auto init_sensor_id = [&](const char * mj_name, const char * mc_name, const std::string & sensor_name,
                             const char * suffix, mjtSensor type, std::unordered_map<std::string, int> & mapping) {
     auto mj_sensor = prefixed(fmt::format("{}_{}", sensor_name, suffix));
@@ -361,50 +365,44 @@ void MjSimImpl::setSimulationInitialState()
 {
   if(controller)
   {
-    qInit.resize(0);
-    alphaInit.resize(0);
-
     for(auto & o : objects)
     {
-      sva::PTransformd pose = o.init_pose;
-      const auto & t = pose.translation();
-      for(size_t i = 0; i < 3; ++i)
-      {
-        qInit.push_back(t[i]);
-        alphaInit.push_back(0);
-        alphaInit.push_back(0);
-      }
-      Eigen::Quaterniond q = Eigen::Quaterniond(pose.rotation()).inverse();
-      qInit.push_back(q.w());
-      qInit.push_back(q.x());
-      qInit.push_back(q.y());
-      qInit.push_back(q.z());
+      // TODO: Initialization of objects qpos is not supported. How can I get the root joint id in mjModel?
+      // sva::PTransformd pose = o.init_pose;
+      // const auto & t = pose.translation();
+      // for(size_t i = 0; i < 3; ++i)
+      // {
+      //   qInit.push_back(t[i]);
+      //   alphaInit.push_back(0);
+      //   alphaInit.push_back(0);
+      // }
+      // Eigen::Quaterniond q = Eigen::Quaterniond(pose.rotation()).inverse();
+      // qInit.push_back(q.w());
+      // qInit.push_back(q.x());
+      // qInit.push_back(q.y());
+      // qInit.push_back(q.z());
     }
 
     for(auto & r : robots)
     {
       const auto & robot = controller->robots().robot(r.name);
       r.initialize(model, robot);
-      if(r.root_joint.size())
+      if(r.root_joint_id != -1)
       {
-        r.root_qpos_idx = qInit.size();
-        r.root_qvel_idx = alphaInit.size();
-        if(robot.mb().joint(0).dof() == 6)
-        {
-          const auto & t = robot.posW().translation();
-          for(size_t i = 0; i < 3; ++i)
-          {
-            qInit.push_back(t[i]);
-            // push linear/angular velocities
-            alphaInit.push_back(0);
-            alphaInit.push_back(0);
-          }
-          Eigen::Quaterniond q = Eigen::Quaterniond(robot.posW().rotation()).inverse();
-          qInit.push_back(q.w());
-          qInit.push_back(q.x());
-          qInit.push_back(q.y());
-          qInit.push_back(q.z());
-        }
+        r.root_qpos_idx = model->jnt_qposadr[r.root_joint_id];
+        r.root_qvel_idx = model->jnt_dofadr[r.root_joint_id];
+        const auto & t = robot.posW().translation();
+        data->qpos[r.root_qpos_idx + 0] = t.x();
+        data->qpos[r.root_qpos_idx + 1] = t.y();
+        data->qpos[r.root_qpos_idx + 2] = t.z();
+        Eigen::Quaterniond q = Eigen::Quaterniond(robot.posW().rotation()).inverse();
+        data->qpos[r.root_qpos_idx + 3] = q.w();
+        data->qpos[r.root_qpos_idx + 4] = q.x();
+        data->qpos[r.root_qpos_idx + 5] = q.y();
+        data->qpos[r.root_qpos_idx + 6] = q.z();
+        // push linear/angular velocities
+        mju_zero3(&data->qvel[r.root_qvel_idx]);
+        mju_zero3(&data->qvel[r.root_qvel_idx + 3]);
       }
       else if(r.root_body_id != -1)
       {
@@ -418,18 +416,18 @@ void MjSimImpl::setSimulationInitialState()
         model->body_quat[4 * r.root_body_id + 2] = q.y();
         model->body_quat[4 * r.root_body_id + 3] = q.z();
       }
-      for(size_t i = 0; i < r.mj_jnt_names.size(); ++i)
+      for(size_t i = 0; i < r.mj_jnt_ids.size(); ++i)
       {
-        qInit.push_back(r.encoders[r.mj_jnt_to_rjo[i]]);
-        alphaInit.push_back(r.alphas[r.mj_jnt_to_rjo[i]]);
+        if(r.mj_jnt_to_rjo[i] == -1)
+        {
+          continue;
+        }
+        data->qpos[model->jnt_qposadr[r.mj_jnt_ids[i]]] = r.encoders[r.mj_jnt_to_rjo[i]];
+        data->qvel[model->jnt_dofadr[r.mj_jnt_ids[i]]] = r.alphas[r.mj_jnt_to_rjo[i]];
       }
     }
   }
-  // set initial qpos, qvel in mujoco
-  if(!mujoco_set_const(model, data, qInit, alphaInit))
-  {
-    mc_rtc::log::error_and_throw<std::runtime_error>("[mc_mujoco] Set inital state failed.");
-  }
+
   mj_forward(model, data);
 }
 

--- a/src/mj_sim_impl.h
+++ b/src/mj_sim_impl.h
@@ -40,6 +40,8 @@ struct MjRobot
   int root_body_id = -1;
   /** Free joint in MuJoCo */
   std::string root_joint;
+  /** Free joint id in MuJoCo */
+  int root_joint_id = -1;
   /** Index of robot's root in qpos, -1 if fixed base */
   int root_qpos_idx = -1;
   /** Index of robot's root in qvel, -1 if fixed base */
@@ -176,12 +178,6 @@ public:
 
   /** MuJoCo data */
   mjData * data = nullptr;
-
-  /** Initial state */
-  std::vector<double> qInit;
-
-  /** Initial velocity */
-  std::vector<double> alphaInit;
 
   /** GLFW window, might be null if the visualization is disabled */
   GLFWwindow * window = nullptr;

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -442,25 +442,6 @@ void mujoco_create_window(MjSimImpl * mj_sim)
   ImGui_ImplOpenGL3_Init(glsl_version);
 }
 
-bool mujoco_set_const(mjModel * m, mjData * d, const std::vector<double> & qpos, const std::vector<double> & qvel)
-{
-  if(qpos.size() != m->nq || qvel.size() != m->nv)
-  {
-    std::cerr << "qpos size: " << qpos.size() << ". Should be: " << m->nq << std::endl;
-    std::cerr << "qvel size: " << qvel.size() << ". Should be: " << m->nv << std::endl;
-    return false;
-  }
-
-  mj_setConst(m, d);
-  const double * qpos_init = &qpos[0];
-  const double * qvel_init = &qvel[0];
-  mju_copy(d->qpos, qpos_init, m->nq);
-  mju_copy(d->qvel, qvel_init, m->nv);
-  d->time = 0.0;
-  mj_forward(m, d);
-  return true;
-}
-
 void mujoco_cleanup(MjSimImpl * mj_sim)
 {
   if(mj_sim->config.with_visualization)

--- a/src/mj_utils.h
+++ b/src/mj_utils.h
@@ -36,9 +36,6 @@ bool mujoco_init(MjSimImpl * mj_sim,
 /*! Create GLFW window */
 void mujoco_create_window(MjSimImpl * mj_sim);
 
-/*! Sets initial qpos and qvel in mjData */
-bool mujoco_set_const(mjModel * m, mjData * d, const std::vector<double> & qpos, const std::vector<double> & qvel);
-
 /** Returns a sensor id from name, -1 if the type does not match or the sensor does not exist */
 int mujoco_get_sensor_id(const mjModel & m, const std::string & name, mjtSensor type);
 


### PR DESCRIPTION
This PR avoids an error in mc_mujoco regarding the number of joints that occurs when soft objects are added. But I am not confident that this is a generic fix. So this PR is intended to share the issue and provide an example of a solution, and is not necessarily expected to be merged.

In MuJoCo, soft bodies are described using [the composite tag](https://mujoco.readthedocs.io/en/latest/modeling.html#composite-objects). This implicitly introduces many virtual joints between the small bodies that make up the soft body.

In my trial, I first created [a file in MJCF format containing the soft body](https://github.com/mmurooka/MultiContactController/blob/60c91c34f25070d903d11af87ca728a0cb39bdcf/mujoco/model/BackContactField.xml#L15-L22) and added it to [the robots of the mc_rtc controller](https://github.com/mmurooka/MultiContactController/blob/60c91c34f25070d903d11af87ca728a0cb39bdcf/.github/workflows/config/MotionBackContact.yaml#L95-L98). The following error occurs in mc_mujoco in the main branch.

```bash
[error]qpos size: 51. Should be: 141
[error]qvel size: 50. Should be: 140
[critical] [mc_mujoco] Set inital state failed.
terminate called after throwing an instance of 'std::runtime_error'
  what():  [mc_mujoco] Set inital state failed.
[critical] === Backtrace ===
{void mc_rtc::log::error_and_throw<std::runtime_error, char const (&) [37]>(char const (&) [37]) at /home/mmurooka/workspace/install/include/mc_rtc/logging.h:52, mc_mujoco::MjSimImpl::setSimulationInitialState() at /home/mmurooka/workspace/ws_mujoco/src/mc_mujoco/src/mj_sim.cpp:431, mc_mujoco::MjSimImpl::startSimulation() at /home/mmurooka/workspace/ws_mujoco/src/mc_mujoco/src/mj_sim.cpp:550, mc_mujoco::MjSim::MjSim(mc_mujoco::MjConfiguration const&) at /home/mmurooka/workspace/ws_mujoco/src/mc_mujoco/src/mj_sim.cpp:1001, main at /home/mmurooka/workspace/ws_mujoco/src/mc_mujoco/src/main.cpp:73, __libc_start_main at ../csu/libc-start.c:342, _start in /home/mmurooka/workspace/ws_mujoco/install/bin/mc_mujoco}
```

Using this PR, a simulation is executed as in the following video, showing the deformation of the soft body.

https://user-images.githubusercontent.com/6636600/236622907-b7749cc7-ff1c-4df0-b189-06e20bc033dd.mp4



