### PR TITLE
Update to build with recent version of MuJoCo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         build-type: [RelWithDebInfo]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
         set -e
         mkdir -p /opt
         cd /opt
-        MUJOCO_VERSION=2.3.1
+        MUJOCO_VERSION=2.3.5
         wget --quiet https://github.com/deepmind/mujoco/releases/download/${MUJOCO_VERSION}/mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
         tar xzf mujoco-${MUJOCO_VERSION}-linux-x86_64.tar.gz
         mv mujoco-${MUJOCO_VERSION} mujoco

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(uitools_is_platform_ui_adapter OFF)
 if(EXISTS ${MUJOCO_INCLUDE_DIR}/uitools.c)
   set(uitools_SRC
     ${MUJOCO_INCLUDE_DIR}/uitools.c
@@ -10,10 +11,20 @@ elseif(EXISTS ${MUJOCO_ROOT_DIR}/simulate/uitools.cc)
     ${MUJOCO_ROOT_DIR}/simulate/uitools.cc
     ${MUJOCO_ROOT_DIR}/simulate/uitools.h
   )
-else()
+elseif(EXISTS ${MUJOCO_SAMPLE_DIR}/uitools.c)
   set(uitools_SRC
     ${MUJOCO_SAMPLE_DIR}/uitools.c
     ${MUJOCO_SAMPLE_DIR}/uitools.h
+  )
+else()
+  set(uitools_is_platform_ui_adapter ON)
+  set(uitools_SRC
+    ${MUJOCO_ROOT_DIR}/simulate/glfw_dispatch.cc
+    ${MUJOCO_ROOT_DIR}/simulate/glfw_dispatch.h
+    ${MUJOCO_ROOT_DIR}/simulate/glfw_adapter.h
+    ${MUJOCO_ROOT_DIR}/simulate/glfw_adapter.cc
+    ${MUJOCO_ROOT_DIR}/simulate/platform_ui_adapter.h
+    ${MUJOCO_ROOT_DIR}/simulate/platform_ui_adapter.cc
   )
 endif()
 
@@ -78,6 +89,9 @@ add_subdirectory("${mc_rtc-imgui_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/mc_rtc-imgui
 configure_file(config.in.h "${CMAKE_CURRENT_BINARY_DIR}/include/config.h")
 
 add_library(mc_mujoco_lib STATIC ${mc_mujoco_lib_SRC} ${imgui_SRC} ${implot_SRC} ${ImGuizmo_SRC} ${mc_rtc-imgui-SRC} ${mc_rtc-imgui-HDR} $<TARGET_OBJECTS:pugixml>)
+if(uitools_is_platform_ui_adapter)
+  target_compile_definitions(mc_mujoco_lib PRIVATE USE_UI_ADAPTER)
+endif()
 target_include_directories(mc_mujoco_lib PUBLIC ${MUJOCO_INCLUDE_DIR} $<BUILD_INTERFACE:${MUJOCO_SAMPLE_DIR}> $<BUILD_INTERFACE:${MUJOCO_SIMULATE_DIR}> $<INSTALL_INTERFACE:include>)
 if(DEFINED MUJOCO_ROOT_INCLUDE_DIR)
   target_include_directories(mc_mujoco_lib PUBLIC ${MUJOCO_ROOT_INCLUDE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,14 +18,19 @@ elseif(EXISTS ${MUJOCO_SAMPLE_DIR}/uitools.c)
   )
 else()
   set(uitools_is_platform_ui_adapter ON)
+  set(OUR_GLFW_ADAPTER_HDR ${CMAKE_CURRENT_BINARY_DIR}/include/our_glfw_adapter.h)
   set(uitools_SRC
     ${MUJOCO_ROOT_DIR}/simulate/glfw_dispatch.cc
     ${MUJOCO_ROOT_DIR}/simulate/glfw_dispatch.h
-    ${MUJOCO_ROOT_DIR}/simulate/glfw_adapter.h
     ${MUJOCO_ROOT_DIR}/simulate/glfw_adapter.cc
     ${MUJOCO_ROOT_DIR}/simulate/platform_ui_adapter.h
     ${MUJOCO_ROOT_DIR}/simulate/platform_ui_adapter.cc
+    ${OUR_GLFW_ADAPTER_HDR}
   )
+  # Make private members public so we can access the window_ field
+  file(READ "${MUJOCO_ROOT_DIR}/simulate/glfw_adapter.h" GLFW_ADAPTER_SRC)
+  string(REPLACE "private:" "public:" GLFW_ADAPTER_SRC "${GLFW_ADAPTER_SRC}")
+  file(GENERATE OUTPUT "${OUR_GLFW_ADAPTER_HDR}" CONTENT "${GLFW_ADAPTER_SRC}")
 endif()
 
 set(mc_mujoco_lib_SRC

--- a/src/MujocoClient.cpp
+++ b/src/MujocoClient.cpp
@@ -64,7 +64,11 @@ inline ImVec2 to_screen(const Eigen::Vector3d & point,
 
 } // namespace internal
 
+#ifdef USE_UI_ADAPTER
+void MujocoClient::draw2D(mujoco::PlatformUIAdapter & window)
+#else
 void MujocoClient::draw2D(GLFWwindow * window)
+#endif
 {
   glGetFloatv(GL_MODELVIEW_MATRIX, view_.data());
   glGetFloatv(GL_PROJECTION_MATRIX, projection_.data());
@@ -74,7 +78,11 @@ void MujocoClient::draw2D(GLFWwindow * window)
 
   int width;
   int height;
+#ifdef USE_UI_ADAPTER
+  std::tie(width, height) = window.GetWindowSize();
+#else
   glfwGetWindowSize(window, &width, &height);
+#endif
   width_ = static_cast<float>(width);
   height_ = static_cast<float>(height);
 

--- a/src/MujocoClient.h
+++ b/src/MujocoClient.h
@@ -6,6 +6,8 @@
 #include "imgui.h"
 #include "mujoco.h"
 
+#include "platform_ui_adapter.h"
+
 namespace mc_mujoco
 {
 
@@ -20,7 +22,11 @@ struct MujocoClient : public mc_rtc::imgui::Client
 {
   using mc_rtc::imgui::Client::Client;
 
+#ifdef USE_UI_ADAPTER
+  void draw2D(mujoco::PlatformUIAdapter & window);
+#else
   void draw2D(GLFWwindow * window);
+#endif
 
   void draw3D();
 

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -22,6 +22,10 @@ namespace bfs = boost::filesystem;
 
 #include <mc_rtc/version.h>
 
+#ifdef USE_UI_ADAPTER
+#  include "glfw_adapter.h"
+#endif
+
 namespace mc_mujoco
 {
 
@@ -102,7 +106,8 @@ bool MjRobot::loadGain(const std::string & path_to_pd, const std::vector<std::st
 }
 
 MjSimImpl::MjSimImpl(const MjConfiguration & config)
-: controller(std::make_unique<mc_control::MCGlobalController>(config.mc_config)), config(config)
+: controller(std::make_unique<mc_control::MCGlobalController>(config.mc_config)), config(config),
+  platform_ui_adapter(new mujoco::GlfwAdapter())
 {
   auto get_robot_cfg_path = [&](const std::string & robot_name) -> std::string {
     if(bfs::exists(bfs::path(mc_mujoco::USER_FOLDER) / (robot_name + ".yaml")))
@@ -843,7 +848,11 @@ bool MjSimImpl::render()
   }
 
   // mj render
+#ifdef USE_UI_ADAPTER
+  mjr_render(platform_ui_adapter->state().rect[0], &scene, &platform_ui_adapter->mjr_context());
+#else
   mjr_render(uistate.rect[0], &scene, &context);
+#endif
 
   // Render ImGui
   ImGui_ImplOpenGL3_NewFrame();
@@ -856,7 +865,11 @@ bool MjSimImpl::render()
   if(client)
   {
     client->update();
+#ifdef USE_UI_ADAPTER
+    client->draw2D(*platform_ui_adapter);
+#else
     client->draw2D(window);
+#endif
     client->draw3D();
   }
   {
@@ -944,9 +957,17 @@ bool MjSimImpl::render()
   ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
   // swap OpenGL buffers (blocking call due to v-sync)
+#ifdef USE_UI_ADAPTER
+  platform_ui_adapter->SwapBuffers();
+#else
   glfwSwapBuffers(window);
+#endif
 
+#ifdef USE_UI_ADAPTER
+  return !platform_ui_adapter->ShouldCloseWindow();
+#else
   return !glfwWindowShouldClose(window);
+#endif
 }
 
 void MjSimImpl::stopSimulation() {}

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -23,7 +23,7 @@ namespace bfs = boost::filesystem;
 #include <mc_rtc/version.h>
 
 #ifdef USE_UI_ADAPTER
-#  include "glfw_adapter.h"
+#  include "our_glfw_adapter.h"
 #endif
 
 namespace mc_mujoco

--- a/src/mj_sim_impl.h
+++ b/src/mj_sim_impl.h
@@ -6,6 +6,10 @@
 
 #include "mujoco.h"
 
+#ifdef USE_UI_ADAPTER
+#  include "platform_ui_adapter.h"
+#endif
+
 #include <condition_variable>
 
 namespace mc_mujoco
@@ -183,8 +187,19 @@ public:
   /** Initial velocity */
   std::vector<double> alphaInit;
 
+#ifndef USE_UI_ADAPTER
   /** GLFW window, might be null if the visualization is disabled */
   GLFWwindow * window = nullptr;
+
+  /** GPU context */
+  mjrContext context;
+
+  /** Keyboard and mouse states */
+  mjuiState uistate;
+#else
+  /** Platform UI adapter */
+  std::unique_ptr<mujoco::PlatformUIAdapter> platform_ui_adapter;
+#endif
 
   /** Camera */
   mjvCamera camera;
@@ -197,12 +212,6 @@ public:
 
   /** Mouse perturbations */
   mjvPerturb pert;
-
-  /** GPU context */
-  mjrContext context;
-
-  /** Keyboard and mouse states */
-  mjuiState uistate;
 
   /** Start of the previous iteration */
   clock::time_point mj_sim_start_t;

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -1,6 +1,11 @@
 #include "glfw3.h"
 #include "mujoco.h"
-#include "uitools.h"
+
+#ifndef USE_UI_ADAPTER
+#  include "uitools.h"
+#else
+#  include "glfw_adapter.h"
+#endif
 
 #include "mj_utils.h"
 
@@ -19,6 +24,26 @@
 
 #include <boost/filesystem.hpp>
 namespace bfs = boost::filesystem;
+
+#ifdef USE_UI_ADAPTER
+// Use the trick to get access to GlfwAdapter private member
+// https://stackoverflow.com/questions/424104/can-i-access-private-members-from-outside-the-class-without-using-friends
+struct GlfwAdapter_Window
+{
+  using type = GLFWwindow * mujoco::GlfwAdapter::*;
+  friend type get(GlfwAdapter_Window);
+};
+
+template<typename Tag, typename Tag::type M>
+struct GetPrivateMember
+{
+  friend typename Tag::type get(Tag)
+  {
+    return M;
+  }
+};
+template struct GetPrivateMember<GlfwAdapter_Window, &mujoco::GlfwAdapter::window_>;
+#endif
 
 namespace mc_mujoco
 {
@@ -45,7 +70,11 @@ void uiLayout(mjuiState * state)
   // rect 0: entire framebuffer
   rect[0].left = 0;
   rect[0].bottom = 0;
+#ifdef USE_UI_ADAPTER
+  std::tie(rect[0].width, rect[0].height) = mj_sim->platform_ui_adapter->GetFramebufferSize();
+#else
   glfwGetFramebufferSize(mj_sim->window, &rect[0].width, &rect[0].height);
+#endif
 }
 
 // handle UI event
@@ -320,6 +349,9 @@ bool mujoco_init(MjSimImpl * mj_sim,
 
 void mujoco_create_window(MjSimImpl * mj_sim)
 {
+#ifdef USE_UI_ADAPTER
+  mj_sim->platform_ui_adapter->SetWindowTitle("mc_mujoco");
+#else
   // Initialize GLFW
   if(!glfw_initialized)
   {
@@ -339,6 +371,7 @@ void mujoco_create_window(MjSimImpl * mj_sim)
   glfwMakeContextCurrent(mj_sim->window);
   glfwSwapInterval(1);
   glfwSetWindowUserPointer(mj_sim->window, static_cast<void *>(mj_sim));
+#endif
 
   // initialize visualization data structures
   auto config = [&]() -> mc_rtc::Configuration {
@@ -379,20 +412,36 @@ void mujoco_create_window(MjSimImpl * mj_sim)
   mj_sim->options.flags[mjVIS_CONTACTFORCE] = visualize("contact-forces", false);
   mj_sim->options.flags[mjVIS_CONTACTSPLIT] = visualize("contact-split", false);
   mjv_defaultScene(&mj_sim->scene);
+#ifndef USE_UI_ADAPTER
   mjr_defaultContext(&mj_sim->context);
+#endif
 
   // create scene and context
   mjv_makeScene(mj_sim->model, &mj_sim->scene, 2000);
+#ifdef USE_UI_ADAPTER
+  mjr_makeContext(mj_sim->model, &mj_sim->platform_ui_adapter->mjr_context(), mjFONTSCALE_150);
+#else
   mjr_makeContext(mj_sim->model, &mj_sim->context, mjFONTSCALE_150);
+#endif
 
   // install GLFW event callback
-  mj_sim->uistate.userdata = static_cast<void *>(mj_sim);
-#if mjVERSION_HEADER >= 230
-  uiSetCallback(mj_sim->window, &mj_sim->uistate, uiEvent, uiLayout, uiRender, nullptr);
+#ifdef USE_UI_ADAPTER
+  auto & uistate = mj_sim->platform_ui_adapter->state();
 #else
-  uiSetCallback(mj_sim->window, &mj_sim->uistate, uiEvent, uiLayout);
+  auto & uistate = mj_sim->uistate;
 #endif
-  uiLayout(&mj_sim->uistate);
+  uistate.userdata = static_cast<void *>(mj_sim);
+#ifndef USE_UI_ADAPTER
+#  if mjVERSION_HEADER >= 230
+  uiSetCallback(mj_sim->window, &mj_sim->uistate, uiEvent, uiLayout, uiRender, nullptr);
+#  else
+  uiSetCallback(mj_sim->window, &mj_sim->uistate, uiEvent, uiLayout);
+#  endif
+#else
+  mj_sim->platform_ui_adapter->SetEventCallback(uiEvent);
+  mj_sim->platform_ui_adapter->SetLayoutCallback(uiLayout);
+#endif
+  uiLayout(&uistate);
 
   /** Initialize Dear Imgui */
 
@@ -438,7 +487,12 @@ void mujoco_create_window(MjSimImpl * mj_sim)
   style.FrameRounding = 6.0f;
   auto & bgColor = style.Colors[ImGuiCol_WindowBg];
   bgColor.w = 0.5f;
+#ifdef USE_UI_ADAPTER
+  auto & glfw_adapter = *dynamic_cast<mujoco::GlfwAdapter *>(mj_sim->platform_ui_adapter.get());
+  ImGui_ImplGlfw_InitForOpenGL(glfw_adapter.*get(GlfwAdapter_Window()), true);
+#else
   ImGui_ImplGlfw_InitForOpenGL(mj_sim->window, true);
+#endif
   ImGui_ImplOpenGL3_Init(glsl_version);
 }
 
@@ -470,11 +524,15 @@ void mujoco_cleanup(MjSimImpl * mj_sim)
     ImGui_ImplGlfw_Shutdown();
     ImGui::DestroyContext();
 
+#ifndef USE_UI_ADAPTER
     glfwDestroyWindow(mj_sim->window);
+#endif
 
     // free visualization storage
     mjv_freeScene(&mj_sim->scene);
+#ifndef USE_UI_ADAPTER
     mjr_freeContext(&mj_sim->context);
+#endif
   }
 
   // free MuJoCo model and data, deactivate

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -4,7 +4,7 @@
 #ifndef USE_UI_ADAPTER
 #  include "uitools.h"
 #else
-#  include "glfw_adapter.h"
+#  include "our_glfw_adapter.h"
 #endif
 
 #include "mj_utils.h"
@@ -24,26 +24,6 @@
 
 #include <boost/filesystem.hpp>
 namespace bfs = boost::filesystem;
-
-#ifdef USE_UI_ADAPTER
-// Use the trick to get access to GlfwAdapter private member
-// https://stackoverflow.com/questions/424104/can-i-access-private-members-from-outside-the-class-without-using-friends
-struct GlfwAdapter_Window
-{
-  using type = GLFWwindow * mujoco::GlfwAdapter::*;
-  friend type get(GlfwAdapter_Window);
-};
-
-template<typename Tag, typename Tag::type M>
-struct GetPrivateMember
-{
-  friend typename Tag::type get(Tag)
-  {
-    return M;
-  }
-};
-template struct GetPrivateMember<GlfwAdapter_Window, &mujoco::GlfwAdapter::window_>;
-#endif
 
 namespace mc_mujoco
 {
@@ -489,7 +469,7 @@ void mujoco_create_window(MjSimImpl * mj_sim)
   bgColor.w = 0.5f;
 #ifdef USE_UI_ADAPTER
   auto & glfw_adapter = *dynamic_cast<mujoco::GlfwAdapter *>(mj_sim->platform_ui_adapter.get());
-  ImGui_ImplGlfw_InitForOpenGL(glfw_adapter.*get(GlfwAdapter_Window()), true);
+  ImGui_ImplGlfw_InitForOpenGL(glfw_adapter.window_, true);
 #else
   ImGui_ImplGlfw_InitForOpenGL(mj_sim->window, true);
 #endif


### PR DESCRIPTION
This PR follows the changes in recent MuJoCo releases and uses the platform ui adapter to interact with GLFW. We still need to access the GLFW window handle to initialize imgui so we copy the glfw_adapter from MuJoCo release to mc_mujoco but replace the private accessor by a public one.

Closes #38