### PR TITLE
Multiple fixes for loading external objects

### DIFF
--- a/robots/CMakeLists.txt
+++ b/robots/CMakeLists.txt
@@ -13,3 +13,4 @@ endfunction()
 
 setup_env_object(ground env)
 setup_env_object(box object)
+setup_env_object(longtable object)

--- a/robots/longtable.xml
+++ b/robots/longtable.xml
@@ -17,13 +17,12 @@
 
     <worldbody>
       <body name="base_link">
-	<light mode="fixed" directional="false" diffuse=".8 .8 .8" specular="0.3 0.3 0.3" pos="0 0 -4.0" dir="0 0 1" />
-        <freejoint name="root" />
+        <light mode="fixed" directional="false" diffuse=".8 .8 .8" specular="0.3 0.3 0.3" pos="0 0 -4.0" dir="0 0 1" />
         <geom class="collision" type="box" size="0.5 0.75 .02" rgba="0.266754 0.174546 0.0644028 1" />
-        <geom class="collision" type="cylinder" size="0.03 0.2" pos="0.4 -0.7 0.58"  rgba="0.266754 0.174546 0.0644028 1" />
-        <geom class="collision" type="cylinder" size="0.03 0.2" pos="-0.4 -0.7 0.58"  rgba="0.266754 0.174546 0.0644028 1" />
-        <geom class="collision" type="cylinder" size="0.03 0.2" pos="0.4 0.7 0.58"  rgba="0.266754 0.174546 0.0644028 1" />
-        <geom class="collision" type="cylinder" size="0.03 0.2" pos="-0.4 0.7 0.58"  rgba="0.266754 0.174546 0.0644028 1" />
+        <geom class="collision" type="cylinder" size="0.03 0.39" pos="0.4 -0.7 0.39"  rgba="0.266754 0.174546 0.0644028 1" />
+        <geom class="collision" type="cylinder" size="0.03 0.39" pos="-0.4 -0.7 0.39"  rgba="0.266754 0.174546 0.0644028 1" />
+        <geom class="collision" type="cylinder" size="0.03 0.39" pos="0.4 0.7 0.39"  rgba="0.266754 0.174546 0.0644028 1" />
+        <geom class="collision" type="cylinder" size="0.03 0.39" pos="-0.4 0.7 0.39"  rgba="0.266754 0.174546 0.0644028 1" />
         <geom class="visual" type="mesh" mesh="longtable_mesh" material="matmarble" />
       </body>
     </worldbody>

--- a/src/mj_sim_impl.h
+++ b/src/mj_sim_impl.h
@@ -35,8 +35,16 @@ struct MjObject
   int root_body_id = -1;
   /** Free joint in MuJoCo */
   std::string root_joint;
-  /** Index of robot's root in qpos, -1 if fixed base */
+  /** Root joint type */
+  mjtJoint root_joint_type = mjJNT_FREE;
+  /** Index of robot's root in qpos, -1 if nq == 0 */
   int root_qpos_idx = -1;
+  /** Index of robot's root in qvel, -1 if ndof == 0 */
+  int root_qvel_idx = -1;
+  /** Number of generalized coordinates */
+  int nq = -1;
+  /** Number of dof */
+  int ndof = -1;
 
   /** Initialize some data after the simulation has started */
   void initialize(mjModel * model);

--- a/src/mj_sim_impl.h
+++ b/src/mj_sim_impl.h
@@ -29,6 +29,17 @@ struct MjObject
   std::string name;
   /** Initial pose in world frame */
   sva::PTransformd init_pose;
+  /** Root body name in MuJoCo */
+  std::string root_body;
+  /** Root body id */
+  int root_body_id = -1;
+  /** Free joint in MuJoCo */
+  std::string root_joint;
+  /** Index of robot's root in qpos, -1 if fixed base */
+  int root_qpos_idx = -1;
+
+  /** Initialize some data after the simulation has started */
+  void initialize(mjModel * model);
 };
 
 /** Interface between a Mujoco robot and an mc_rtc robot */

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -312,7 +312,7 @@ bool mujoco_init(MjSimImpl * mj_sim,
 #endif
 
   // Load the model;
-  std::string model = merge_mujoco_models(mujocoObjects, mcrtcObjects, mj_sim->robots);
+  std::string model = merge_mujoco_models(mujocoObjects, mcrtcObjects, mj_sim->objects, mj_sim->robots);
   char error[1000] = "Could not load XML model";
   mj_sim->model = mj_loadXML(model.c_str(), 0, error, 1000);
   if(!mj_sim->model)

--- a/src/mj_utils.h
+++ b/src/mj_utils.h
@@ -18,14 +18,19 @@ namespace mc_mujoco
  * Warnings are displayed when some global parameters conflict, in such cases, the value from the first model where the
  * parameter appeared will prevail
  *
- * \param robots Prefix applied to each model
+ * \param mujocoObjects Objects added to the simulation but not in mc_rtc
  *
- * \param xmlFiles Individual models
+ * \param mcrtcObjects Objects added to the simulation and to mc_rtc
+ *
+ * \param mjObjects MuJoCo ids for objects not in mc_rtc will be filled with parameters in the merged model
+ *
+ * \param mjRobots MuJoCo ids for objects in mc_rtc will be filled with parameters in the merged model
  *
  * \returns The path to the generated model
  */
 std::string merge_mujoco_models(const std::map<std::string, std::string> & mujocoObjects,
                                 const std::map<std::string, std::string> & mcrtcObjects,
+                                std::vector<MjObject> & mjObjects,
                                 std::vector<MjRobot> & mjRobots);
 
 /*! Load XML model and initialize */

--- a/src/mj_utils_merge_mujoco_models.cpp
+++ b/src/mj_utils_merge_mujoco_models.cpp
@@ -114,7 +114,7 @@ static void add_prefix_recursively(const std::string & prefix,
   }
   for(const auto & attr : attrs)
   {
-    add_prefix(prefix, out, attr.c_str());
+    add_prefix(prefix, out, attr.c_str(), strcmp("freejoint", out.name()) == 0 && attr == "name");
   }
   for(auto & c : out.children())
   {
@@ -481,7 +481,8 @@ static void mj_object_from_xml(const std::string & name, const std::string & xml
   object.root_body = fmt::format("{}_{}", name, root_body);
   if(model->nq > 0)
   {
-    object.root_joint = fmt::format("{}_{}", name, mj_id2name(model, mjOBJ_JOINT, 0));
+    auto root_joint = mj_id2name(model, mjOBJ_JOINT, 0);
+    object.root_joint = fmt::format("{}_{}", name, root_joint ? root_joint : "");
     object.root_joint_type = static_cast<mjtJoint>(model->jnt_type[0]);
   }
   object.nq = model->nq;


### PR DESCRIPTION
This PR addresses the issues raised in #39:
- Static objects can now be loaded as external objects
- Composite objects can now be loaded as external objects
- Extra modules can be loaded from the user folder instead of the global installation folder

For now we still don't allow a mismatch between the kinematic structure in mc_rtc and the kinematic structure in the corresponding MuJoCo model, this would require a little extra work to handle the gaps in qpos/qvel