### PR TITLE
Use world-sized interactive markers

### DIFF
--- a/ext/ImGuizmo/ImGuizmo.cpp
+++ b/ext/ImGuizmo/ImGuizmo.cpp
@@ -645,7 +645,7 @@ namespace IMGUIZMO_NAMESPACE
 
    struct Context
    {
-      Context() : mbUsing(false), mbEnable(true), mbUsingBounds(false)
+      Context() : mFixedSize(false), mbUsing(false), mbEnable(true), mbUsingBounds(false)
       {
       }
 
@@ -675,6 +675,9 @@ namespace IMGUIZMO_NAMESPACE
       ImVec2 mScreenSquareCenter;
       ImVec2 mScreenSquareMin;
       ImVec2 mScreenSquareMax;
+
+      bool mFixedSize;
+      float mGizmoSizeWorldSpace;
 
       float mScreenFactor;
       vec_t mRelativeOrigin;
@@ -1047,6 +1050,11 @@ namespace IMGUIZMO_NAMESPACE
       rightViewInverse.TransformVector(gContext.mModelInverse);
       float rightLength = GetSegmentLengthClipSpace(makeVect(0.f, 0.f), rightViewInverse);
       gContext.mScreenFactor = gContext.mGizmoSizeClipSpace / rightLength;
+
+      if(gContext.mFixedSize)
+      {
+        gContext.mScreenFactor = gContext.mGizmoSizeWorldSpace;
+      }
 
       ImVec2 centerSSpace = worldToPos(makeVect(0.f, 0.f), gContext.mMVP);
       gContext.mScreenSquareCenter = centerSSpace;
@@ -2466,7 +2474,14 @@ namespace IMGUIZMO_NAMESPACE
 
    void SetGizmoSizeClipSpace(float value)
    {
+      gContext.mFixedSize = false;
       gContext.mGizmoSizeClipSpace = value;
+   }
+
+   void SetGizmoSizeWorldSpace(float value)
+   {
+      gContext.mFixedSize = true;
+      gContext.mGizmoSizeWorldSpace = value;
    }
 
    ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ext/ImGuizmo/ImGuizmo.h
+++ b/ext/ImGuizmo/ImGuizmo.h
@@ -216,6 +216,9 @@ namespace IMGUIZMO_NAMESPACE
    IMGUI_API bool IsOver(OPERATION op);
    IMGUI_API void SetGizmoSizeClipSpace(float value);
 
+   // Set a fixed (world-space) size for the widgets
+   IMGUI_API void SetGizmoSizeWorldSpace(float value);
+
    // Allow axis to flip
    // When true (default), the guizmo axis flip for better visibility
    // When false, they always stay along the positive world/local axis

--- a/src/widgets/details/InteractiveMarker.cpp
+++ b/src/widgets/details/InteractiveMarker.cpp
@@ -59,6 +59,7 @@ bool InteractiveMarker::draw(const std::array<float, 16> & view, const std::arra
     return false;
   }
   ImGuizmo::SetID(id_);
+  ImGuizmo::SetGizmoSizeWorldSpace(0.15f);
   Eigen::Matrix<float, 4, 4> mat = sva::conversions::toHomogeneous(pose_.cast<float>());
   auto op = static_cast<ImGuizmo::OPERATION>(operation_);
   bool changed = ImGuizmo::Manipulate(view.data(), projection.data(), op, ImGuizmo::MODE::LOCAL, mat.data());


### PR DESCRIPTION
This PR changes the display size of ImGuizmo widgets such that they have a fixed size in the world. It is especially nicer in cluttered scene that are zoomed out