### PR TITLE
Improve initialization of qpos and qvel

### DIFF
--- a/src/mj_sim_impl.h
+++ b/src/mj_sim_impl.h
@@ -200,12 +200,6 @@ public:
   /** MuJoCo data */
   mjData * data = nullptr;
 
-  /** Initial state */
-  std::vector<double> qInit;
-
-  /** Initial velocity */
-  std::vector<double> alphaInit;
-
 #ifndef USE_UI_ADAPTER
   /** GLFW window, might be null if the visualization is disabled */
   GLFWwindow * window = nullptr;

--- a/src/mj_utils.cpp
+++ b/src/mj_utils.cpp
@@ -477,25 +477,6 @@ void mujoco_create_window(MjSimImpl * mj_sim)
   ImGui_ImplOpenGL3_Init(glsl_version);
 }
 
-bool mujoco_set_const(mjModel * m, mjData * d, const std::vector<double> & qpos, const std::vector<double> & qvel)
-{
-  if(qpos.size() != m->nq || qvel.size() != m->nv)
-  {
-    std::cerr << "qpos size: " << qpos.size() << ". Should be: " << m->nq << std::endl;
-    std::cerr << "qvel size: " << qvel.size() << ". Should be: " << m->nv << std::endl;
-    return false;
-  }
-
-  mj_setConst(m, d);
-  const double * qpos_init = &qpos[0];
-  const double * qvel_init = &qvel[0];
-  mju_copy(d->qpos, qpos_init, m->nq);
-  mju_copy(d->qvel, qvel_init, m->nv);
-  d->time = 0.0;
-  mj_forward(m, d);
-  return true;
-}
-
 void mujoco_cleanup(MjSimImpl * mj_sim)
 {
   if(mj_sim->config.with_visualization)

--- a/src/mj_utils.h
+++ b/src/mj_utils.h
@@ -41,9 +41,6 @@ bool mujoco_init(MjSimImpl * mj_sim,
 /*! Create GLFW window */
 void mujoco_create_window(MjSimImpl * mj_sim);
 
-/*! Sets initial qpos and qvel in mjData */
-bool mujoco_set_const(mjModel * m, mjData * d, const std::vector<double> & qpos, const std::vector<double> & qvel);
-
 /** Returns a sensor id from name, -1 if the type does not match or the sensor does not exist */
 int mujoco_get_sensor_id(const mjModel & m, const std::string & name, mjtSensor type);
 


### PR DESCRIPTION
This patch should solve the following remaining issue mentioned in [the previous PR](https://github.com/rohanpsingh/mc_mujoco/pull/43#issue-1715107944).
(I don't see the benefit of keeping `qInit` or `alphaInit` explicitly, so I deleted them and directly set `data->qpos` or `data->qvel`, but please correct me if I'm wrong)

> For now we still don't allow a mismatch between the kinematic structure in mc_rtc and the kinematic structure in the corresponding MuJoCo model, this would require a little extra work to handle the gaps in qpos/qvel

