### PR TITLE
Add a robot-name prefix to class attributes of material elements

### DIFF
--- a/src/mj_utils_merge_mujoco_models.cpp
+++ b/src/mj_utils_merge_mujoco_models.cpp
@@ -213,6 +213,7 @@ static void merge_mujoco_asset(const pugi::xml_node & in,
     auto mat_out = out.append_copy(mat);
     update_name(mat_out);
     add_prefix(robot, mat_out, "texture");
+    add_prefix(robot, mat_out, "class");
   }
   copy_assets("texture", texturePath);
   copy_assets("mesh", meshPath);


### PR DESCRIPTION
This patch is necessary to deal with universal robot UR5e.
https://github.com/deepmind/mujoco_menagerie/blob/main/universal_robots_ur5e/ur5e.xml#L35C15-L35C27