### PR TITLE
Add SetPosW callbacks in the datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # mujoco interface for mc-rtc
+
 ![Screenshot from 2022-08-12 17-09-16](https://user-images.githubusercontent.com/16384313/188832982-1a1263e4-ce33-4dc7-804a-589d151670b3.png)
 
-
 ## Usage
+
 First, install the required apt packages:
+
 ```sh
 $ sudo apt install libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libglew-dev
 ```
 
 Then, assuming that you have mujoco installed under `${HOME}/.mujoco/mujoco235`,
+
 ```sh
 $ git clone --recursive git@github.com:rohanpsingh/mc_mujoco.git
 $ cd mc_mujoco
@@ -17,24 +20,32 @@ $ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMUJOCO_ROOT_DIR=$HOME/.mujoco/muj
 $ make
 $ make install
 ```
+
 Add the following line to your `~/.bashrc`:
+
 ```
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${HOME}/.mujoco/mujoco235/lib:${HOME}/.mujoco/mujoco235/bin
 ```
+
 Then, to run the interface:
+
 ```sh
 $ mc_mujoco
 ```
+
 ---
 
 #### To load additional objects in the scene
+
 There are several steps needed to be followed:
+
 - First, create your object's XML file under `mc_mujoco/robots`. For example, [longtable.xml](robots/longtable.xml)
 - Then, create a simple config file with the `xmlModelPath` attribute. For example, [longtable.in.yaml](robots/longtable.in.yaml)
-- Then, install your object by adding it to the end of `mc_mujoco/robots/CMakeLists.txt`. For example, add [setup_env_object(box object)](robots/CMakeLists.txt#L15)  
+- Then, install your object by adding it to the end of `mc_mujoco/robots/CMakeLists.txt`. For example, add [setup_env_object(box object)](robots/CMakeLists.txt#L15)
 
 Your object is now created and installed. Next you want to tell `mc-mujoco` to load it and place it at the desired pose.  
 Find `~/.config/mc_rtc/mc_mujoco/mc_mujoco.yaml` (create it manually if needed) and paste the following:
+
 ```yaml
 objects:
   box1:
@@ -48,14 +59,17 @@ objects:
       translation: [3.7, 0.2, 0.9]
       rotation: [0, 0, 0]
 ```
+
 ---
 
 #### To load MuJoCo plugins
 
 To load [MuJoCo plugins](https://mujoco.readthedocs.io/en/latest/programming/extension.html#engine-plugins), specify the paths to the directories containing the plugin libraries in the `PluginPaths` entry in `~/.config/mc_rtc/mc_mujoco/mc_mujoco.yaml`.
+
 ```yaml
 PluginPaths: ["<path-to-plugins>"]
 ```
+
 ---
 
 #### GUI: Mouse Interaction
@@ -66,7 +80,20 @@ An object is selected by left-double-click. The user can then apply forces and t
 
 A basic example of what you can do using this package is [here](https://github.com/rohanpsingh/grasp-fsm-sample-controller).
 
+## Datastore callbacks
+
+The following callbacks are available for the controller when running inside `mc_mujoco`
+
+| Signature                                                                           | Description                                                                                                        |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `{robot}::SetPosW(const sva::PTransformd &)`                                         | Set the position of the given `robot`. Also works with objects                                                     |
+| `{robot}::SetPDGains(const std::vector<double> & p, const std::vector<double> & d)` | Set the PD gains for the actuation of the given `robot`. `p` and `d` must follow the robot's reference joint order |
+| `{robot}::SetPDGainsByName(const std::string & jn, double p, double d)`             | Set the PD gains for a given joint `jn` in `robot`                                                                 |
+| `{robot}::GetPDGains(std::vector<double> & p, std::vector<double> & d)`             | Get the current PD gains for `robot` actuation                                                                     |
+| `{robot}::GetPDGainsByName(const std::string & jn, double & p, double & d)`         | Get the current PD gains for a given joint `jn` in `robot`                                                         |
+
 ## Citation
+
 ```
 @inproceedings{singh2023mc,
   title={mc-mujoco: Simulating Articulated Robots with FSM Controllers in MuJoCo},
@@ -81,6 +108,7 @@ A basic example of what you can do using this package is [here](https://github.c
 ### Credits
 
 This package includes code from:
+
 - [imgui v1.84.2](https://github.com/ocornut/imgui/)
 - [implot v0.11](https://github.com/epezent/implot)
 - [ImGuizmo](https://github.com/CedricGuillemet/ImGuizmo)

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -942,11 +942,11 @@ bool MjSimImpl::render()
     client->draw2D(window);
 #endif
     client->draw3D();
-    for(auto & marker : markers)
+    for(auto & [name, marker] : markers)
     {
-      if(marker.marker.draw(client->view(), client->projection()))
+      if(marker.draw(client->view(), client->projection()) || marker.active())
       {
-        setObjectPosW(marker.name, marker.marker.pose());
+        setObjectPosW(name, marker.pose());
       }
     }
   }

--- a/src/mj_sim_impl.h
+++ b/src/mj_sim_impl.h
@@ -63,6 +63,8 @@ struct MjRobot
   int root_body_id = -1;
   /** Free joint in MuJoCo */
   std::string root_joint;
+  /** Root joint type */
+  mjtJoint root_joint_type = mjJNT_FREE;
   /** Index of robot's root in qpos, -1 if fixed base */
   int root_qpos_idx = -1;
   /** Index of robot's root in qvel, -1 if fixed base */
@@ -162,7 +164,7 @@ struct MjRobot
   void sendControl(const mjModel & model, mjData & data, size_t interp_idx, size_t frameskip_, bool torque_control);
 
   /** Run PD control for a given joint */
-  double PD(double jnt_id, double q_ref, double q, double qdot_ref, double qdot);
+  double PD(size_t jnt_id, double q_ref, double q, double qdot_ref, double qdot);
 
   /** Load PD gains from a file */
   bool loadGain(const std::string & path_to_pd, const std::vector<std::string> & joints);
@@ -170,14 +172,11 @@ struct MjRobot
   /** From a name returns the prefixed name in MuJoCo */
   inline std::string prefixed(const std::string & name) const noexcept
   {
-    if(prefix.size())
+    if(!prefix.empty())
     {
       return fmt::format("{}_{}", prefix, name);
     }
-    else
-    {
-      return name;
-    }
+    return name;
   }
 };
 
@@ -259,6 +258,9 @@ private:
   /** Mutex used in rendering */
   std::mutex rendering_mutex_;
 
+  template<typename T>
+  void setPosW(const T & robot, const sva::PTransformd & pos);
+
 public:
   MjSimImpl(const MjConfiguration & config);
 
@@ -285,11 +287,19 @@ public:
   void resetSimulation(const std::map<std::string, std::vector<double>> & reset_qs,
                        const std::map<std::string, sva::PTransformd> & reset_pos);
 
+  // Set the position of an object
+  // No-op if the object is not in the simulation
+  void setObjectPosW(const std::string & object, const sva::PTransformd & pt);
+
+  // Set the position of a robot
+  // No-op if the robot is not in the controller
+  void setRobotPosW(const std::string & robot, const sva::PTransformd & pt);
+
   void setSimulationInitialState();
 
   void saveGUISettings();
 
-  void loadPlugins(const auto & mc_mujoco_cfg) const;
+  void loadPlugins(const mc_rtc::Configuration & mc_mujoco_cfg) const;
 
   inline mc_control::MCGlobalController * get_controller() noexcept
   {

--- a/src/mj_sim_impl.h
+++ b/src/mj_sim_impl.h
@@ -10,6 +10,8 @@
 #  include "platform_ui_adapter.h"
 #endif
 
+#include "widgets/details/InteractiveMarker.h"
+
 #include <condition_variable>
 
 namespace mc_mujoco
@@ -243,6 +245,16 @@ public:
   /** Objects in simulation */
   std::vector<MjObject> objects;
 
+  struct MjObjectMarker
+  {
+    /** Name of the controlled object */
+    std::string name;
+    /** Marker used to manipulate the object */
+    InteractiveMarker marker;
+  };
+  /** Interactive markers to move simulation objects interactively */
+  std::vector<MjObjectMarker> markers;
+
   /*! Simulation wall clock time (seconds) */
   double wallclock;
 
@@ -290,6 +302,10 @@ public:
   // Set the position of an object
   // No-op if the object is not in the simulation
   void setObjectPosW(const std::string & object, const sva::PTransformd & pt);
+
+  // Retrieve the position of an object
+  // Throws if the object does not exist in the simulation
+  sva::PTransformd getObjectPosW(const std::string & object) const;
 
   // Set the position of a robot
   // No-op if the robot is not in the controller

--- a/src/widgets/details/InteractiveMarker.h
+++ b/src/widgets/details/InteractiveMarker.h
@@ -17,6 +17,11 @@ struct InteractiveMarker
 
   void pose(const sva::PTransformd & pose);
 
+  inline bool active() const noexcept
+  {
+    return active_;
+  }
+
   inline const sva::PTransformd & pose() const noexcept
   {
     return pose_;


### PR DESCRIPTION
This PR adds the following:
- datastore callbacks to set the position of objects and robots in the simulation (the robot function does not update the position in the controller, it's up to the programmer to decide whether to do it or not)
- interactive markers to move an object handled by MuJoCo