### PR TITLE
fix: Do not call mc_rtc_set_prefix in user code

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,5 @@
 option(BUILD_EXAMPLES "Build example controllers" ON)
 if(BUILD_EXAMPLES)
+  message(STATUS "Adding example neck_policy")
   add_subdirectory(neck_policy)
 endif()

--- a/examples/neck_policy/CMakeLists.txt
+++ b/examples/neck_policy/CMakeLists.txt
@@ -18,7 +18,7 @@ if(NOT Torch_FOUND)
 endif()
 
 if(NOT TARGET mc_rtc::mc_rtc)
-find_package(mc_rtc REQUIRED)
+  find_package(mc_rtc REQUIRED)
 endif()
 
 add_subdirectory(src)

--- a/examples/neck_policy/CMakeLists.txt
+++ b/examples/neck_policy/CMakeLists.txt
@@ -17,9 +17,9 @@ if(NOT Torch_FOUND)
   find_package(Torch REQUIRED)
 endif()
 
+if(NOT TARGET mc_rtc::mc_rtc)
 find_package(mc_rtc REQUIRED)
-
-mc_rtc_set_prefix(CONTROLLER mc_controller)
+endif()
 
 add_subdirectory(src)
 


### PR DESCRIPTION
This fixes use of MC_RTC_HONOR_INSTALL_PREFIX as of https://github.com/jrl-umi3218/mc_rtc/pull/495: `mc_rtc_set_prefix` is not intended to be called from user code.
