### PR TITLE
fix(docker): version build-cache volume by MUJOCO_VERSION

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,12 @@ cd docker && make ci-test
 
 Inside the container:
 - Source is mounted at `/workspace/mc_mujoco`
-- Build dir: `/workspace/mc_mujoco/build` (persistent Docker volume)
+- Build dir: `/build` — backed by Docker volume `mc_mujoco_build_<MUJOCO_VERSION>`.
+  Volume name encodes the `MUJOCO_VERSION` pin so a version bump automatically
+  points at a fresh cache; `make` prunes stale-version volumes on each run.
 - MuJoCo at `/opt/mujoco`
-- Rebuild: `cmake --build /workspace/mc_mujoco/build`
-- Reinstall: `cmake --install /workspace/mc_mujoco/build`
+- Rebuild: `cmake --build /build`
+- Reinstall: `cmake --install /build`
 - Run standalone tests: `ctest -V --test-dir /ci-build-standalone`
 
 To run arbitrary commands in the dev container:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,18 +1,37 @@
 export DOCKER_BUILDKIT := 1
 
+MUJOCO_VERSION := $(shell tr -d '[:space:]' < ../MUJOCO_VERSION)
+export MUJOCO_VERSION
+
+BUILD_VOLUME := mc_mujoco_build_$(MUJOCO_VERSION)
+
 .PHONY: run ci-test
 
 run:
+	@# Ensure the build cache for the current MUJOCO_VERSION exists, and remove
+	@# any build cache from previous versions (incl. the legacy unversioned name).
+	@# This is what prevents stale .o files compiled against an older MuJoCo
+	@# from silently surviving a version bump.
+	@docker volume create $(BUILD_VOLUME) >/dev/null
+	@for v in $$(docker volume ls -q --filter name=mc_mujoco_build); do \
+	  if [ "$$v" != "$(BUILD_VOLUME)" ]; then \
+	    if docker volume rm "$$v" >/dev/null 2>&1; then \
+	      echo "Removed stale build volume: $$v"; \
+	    else \
+	      echo "WARNING: could not remove stale build volume $$v (likely held by a running container — stop it and re-run 'make' to reclaim)"; \
+	    fi; \
+	  fi; \
+	done
 	@echo "Granting X11 access to docker..."
 	@xhost +local:docker >/dev/null
 	@echo "Building container..."
 	@docker compose -f docker-compose.yml build
 	@echo "Building mc_mujoco and starting shell..."
 	@docker compose -f docker-compose.yml run --rm mc-rtc-mujoco bash -c "\
-		cmake -S /workspace/mc_mujoco -B /workspace/mc_mujoco/build -G Ninja \
+		cmake -S /workspace/mc_mujoco -B /build -G Ninja \
 		    -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMUJOCO_ROOT_DIR=/opt/mujoco && \
-		cmake --build /workspace/mc_mujoco/build && \
-		cmake --install /workspace/mc_mujoco/build ; \
+		cmake --build /build && \
+		cmake --install /build ; \
 		exec bash"
 	@echo "Revoking X11 access..."
 	@xhost -local:docker >/dev/null

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ..:/workspace/mc_mujoco
-      - mc_mujoco_build:/workspace/mc_mujoco/build
+      - mc_mujoco_build:/build
     environment:
       - DISPLAY=${DISPLAY:-:0}
       - ROS_DISTRO=humble
@@ -19,4 +19,9 @@ services:
     tty: true
 
 volumes:
+  # Versioned build cache: name encodes MUJOCO_VERSION so a version bump
+  # automatically targets a fresh volume. Lifecycle (create + prune of stale
+  # versions) is owned by the Makefile, hence external: true.
   mc_mujoco_build:
+    external: true
+    name: mc_mujoco_build_${MUJOCO_VERSION:?MUJOCO_VERSION must be set (run via make)}


### PR DESCRIPTION
The build cache lived in a Docker volume that survived image rebuilds.
After a MuJoCo upgrade, ninja saw .o files newer than the (preserved-
mtime) headers and skipped recompiling them, so structs like mjrContext
got their old layout linked against a libmujoco that wrote the new
larger size — corrupting the heap.

Volume name now encodes MUJOCO_VERSION; the Makefile creates the
current-version volume and prunes any others on each `make run`, so a
version bump automatically gets a fresh cache. Also moves the in-
container build path to /build so it isn't shadowed inside the bind-
mounted source tree (no more empty root-owned build/ on the host).