### PR TITLE
Add toggle to disable mc_rtc visuals in the GUI

### DIFF
--- a/src/MujocoClient.cpp
+++ b/src/MujocoClient.cpp
@@ -106,6 +106,10 @@ void MujocoClient::draw2D(GLFWwindow * window)
 void MujocoClient::draw3D()
 {
   geoms_.clear();
+  if(!show_visuals)
+  {
+    return;
+  }
   mc_rtc::imgui::Client::draw3D();
 }
 

--- a/src/MujocoClient.h
+++ b/src/MujocoClient.h
@@ -34,6 +34,8 @@ struct MujocoClient : public mc_rtc::imgui::Client
 
   void updateScene(mjvScene & scene);
 
+  bool show_visuals = true;
+
   inline const std::array<float, 16> & view() const noexcept
   {
     return view_;

--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -1079,6 +1079,10 @@ bool MjSimImpl::render()
     flag_to_gui("Show contact forces [F]", mjVIS_CONTACTFORCE);
     flag_to_gui("Make Transparent [T]", mjVIS_TRANSPARENT);
     flag_to_gui("Convex Hull rendering [V]", mjVIS_CONVEXHULL);
+    if(client)
+    {
+      ImGui::Checkbox("Show mc_rtc visuals", &client->show_visuals);
+    }
     auto group_to_checkbox = [&](size_t group, bool last)
     {
       bool show = options.geomgroup[group];


### PR DESCRIPTION
Adds a "Show mc_rtc visuals" checkbox in the mc_mujoco menu window
that short-circuits MujocoClient::draw3D(), suppressing all
controller-driven visuals (frames, arrows, spheres, polygons, etc.)
that would otherwise clutter the scene.