### PR TITLE
chore(example): OFF as default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See [docker/README.md](docker/README.md) for details on development workflow, us
 
 ## Examples
 
-Example controllers live under [`examples/`](examples/). Built by default (disable with `-DBUILD_EXAMPLES=OFF`). See [`examples/README.md`](examples/README.md) for the convention and how to activate a sample's config inside the container.
+Example controllers live under [`examples/`](examples/). Not built by default (enable with `-DBUILD_EXAMPLES=ON`). See [`examples/README.md`](examples/README.md) for the convention and how to activate a sample's config inside the container.
 
 - **[neck_policy](examples/neck_policy/)** — Minimal libtorch NN policy that drives JVRC1's neck yaw joint. Good starting point for running NN policies in mc_mujoco.
 - **[grasp-fsm](examples/grasp-fsm/)** *(submodule)* — FSM controller that grasps an object on a table using BaselineWalkingController. Pulled from [grasp-fsm-sample-controller](https://github.com/rohanpsingh/grasp-fsm-sample-controller).

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -31,7 +31,7 @@ run:
 	@echo "Building mc_mujoco and starting shell..."
 	@docker compose -f docker-compose.yml run --rm mc-rtc-mujoco bash -c "\
 		cmake -S /workspace/mc_mujoco -B /build -G Ninja \
-		    -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMUJOCO_ROOT_DIR=/opt/mujoco && \
+		    -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMUJOCO_ROOT_DIR=/opt/mujoco -DBUILD_EXAMPLES=ON && \
 		cmake --build /build && \
 		cmake --install /build ; \
 		exec bash"
@@ -50,7 +50,7 @@ ci-test:
 		cmake --install /ci-build && \
 		echo 'Build passed! Running standalone test...' && \
 		cmake -S /workspace/.github/workflows/test-standalone \
-		    -B /ci-build-standalone -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo && \
+		    -B /ci-build-standalone -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_EXAMPLES=ON && \
 		cmake --build /ci-build-standalone && \
 		ctest -V --test-dir /ci-build-standalone && \
 		echo 'CI test passed!'"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(BUILD_EXAMPLES "Build example controllers" ON)
+option(BUILD_EXAMPLES "Build example controllers" OFF)
 if(NOT BUILD_EXAMPLES)
   return()
 endif()


### PR DESCRIPTION
Hello @rohanpsingh, 

In order to limit dependencies installation when installing `mc_mujoco` out of a docker environment, I'm suggesting with this PR to disable example as default behavior. 

