### PR TITLE
fix: build fails if BUILD_SHARED_LIBS is set to ON when building bundled glfw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,9 @@ if(NOT GLFW)
   set(BUILD_STATIC
       ON
       CACHE BOOL "" FORCE)
+  set(BUILD_SHARED_LIBS
+      OFF
+      CACHE BOOL "" FORCE)
   add_subdirectory(ext/glfw EXCLUDE_FROM_ALL)
 else()
   message(STATUS "GLFW lib found at: " ${GLFW})


### PR DESCRIPTION
If `BUILD_SHARED_LIBS` is set to `ON`, glfw is built as a shared object instead of static even though `BUILD_STATIC` is also set and the combined lib fails to build.

In my case it was set by ROS Lyrical (I suspect that [this pr](https://github.com/ros2/ament_cmake_ros/pull/20) may have something with it) but it is not impossible that I may happen in other ways.