### PR TITLE
Datastore: add GetPosW for objects

### DIFF
--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -567,6 +567,7 @@ void MjSimImpl::makeDatastoreCalls()
   for(auto & o : objects)
   {
     ds.make_call(o.name + "::SetPosW", [this, name = o.name](const sva::PTransformd & pt) { setObjectPosW(name, pt); });
+    ds.make_call(o.name + "::GetPosW", [this, name = o.name]() { return getObjectPosW(name); });
   }
   for(auto & r : robots)
   {


### PR DESCRIPTION
Hello, 

This PR allows users to get the pose of the object from the datastore. 