### PR TITLE
mj_sim: don't call mjv_updateScene when visualization is disabled

### DIFF
--- a/src/mj_sim.cpp
+++ b/src/mj_sim.cpp
@@ -967,6 +967,11 @@ bool MjSimImpl::stepSimulation()
 
 void MjSimImpl::updateScene()
 {
+  if(!config.with_visualization)
+  {
+    return;
+  }
+
   // update scene and render
   std::lock_guard<std::mutex> lock(rendering_mutex_);
   mjv_updateScene(model, data, &options, &pert, &camera, mjCAT_ALL, &scene);


### PR DESCRIPTION
Hello, 

After running some test I noticed that `--without-visualization` option was broken. Leading to the following option : 

```
[error] [mc_mujoco] No MuJoCo gyro sensor for Default body sensor in ground, expected to find a gyro sensor named ground_Default_gyro
[error] [mc_mujoco] No MuJoCo accelerometer sensor for Default body sensor in ground, expected to find a accelerometer sensor named ground_Default_accelerometer
[info] Will log controller outputs to /tmp/mc-control-Posture-2026-07-03-13-41-03.bin
[info] Updated latest log symlink: /tmp/mc-control-Posture-latest.bin
1783053663.368655 [0]  mc_mujoco: selected interface "lo" is not multicast-capable: disabling multicast
[success] [mc_rtc::ROS] Starting ROS services
[error] [mc_mujoco] No MuJoCo gyro sensor for Default body sensor in ground, expected to find a gyro sensor named ground_Default_gyro
[error] [mc_mujoco] No MuJoCo accelerometer sensor for Default body sensor in ground, expected to find a accelerometer sensor named ground_Default_accelerometer
WARNING: Pre-allocated visual geom buffer is full. Increase maxgeom above 0. Time = 0.0000.

ERROR: mjv_updateCamera: unknown camera type

Press Enter to exit ...
```

The problems here comes from the fact that `mujoco_create_window()` initializes camera/options/scene via `mjv_defaultCamera`/`mjv_defaultOption`/`mjv_defaultScene`/`mjv_makeScene `. This only runs when with_visualization is true. updateScene() called mjv_updateScene() unconditionally, reading those never-initialized structs and crashing with
"mjv_cameraFrame: unknown camera type" whenever mc_mujoco was run with
`--without-visualization`.

This PR guards the scene to be rendered when the `without-visualization` option is set. 