### PR TITLE
Revert "fix(ci): add ROS2 ament_index_cpp dependency for mc_rtc linking (#87)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,19 +27,13 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-    - name: Setup ROS 2 apt repository
-      run: |
-        sudo apt-get update && sudo apt-get install -y curl gnupg lsb-release
-        sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-        sudo apt-get update
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master
       with:
         compiler: ${{ matrix.compiler }}
         build-type: ${{ matrix.build-type }}
         ubuntu: |
-          apt: libmc-rtc-dev libxi-dev libxcursor-dev libxkbcommon-dev libxinerama-dev libxrandr-dev libglew-dev libboost-program-options-dev ros-humble-ament-index-cpp
+          apt: libmc-rtc-dev libxi-dev libxcursor-dev libxkbcommon-dev libxinerama-dev libxrandr-dev libglew-dev libboost-program-options-dev
           apt-mirrors:
             mc-rtc:
               cloudsmith: mc-rtc/head
@@ -67,9 +61,6 @@ jobs:
         mv mujoco-${MUJOCO_VERSION} mujoco
         rm -rf *.tar.gz
         echo "MUJOCO_ROOT_DIR=/opt/mujoco" >> $GITHUB_ENV
-        # Setup ROS 2 library paths for linking
-        echo "LD_LIBRARY_PATH=/opt/ros/humble/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "CMAKE_PREFIX_PATH=/opt/ros/humble:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
     - name: Build and test
       uses: jrl-umi3218/github-actions/build-cmake-project@master
       with:


### PR DESCRIPTION
This reverts commit 103fc3ffa20de96f413db42dc512874b94616413.

This should no longer be needed now that mc-rtc packages have been fixed and released. They no longer depend on ROS.